### PR TITLE
Remove redundant khelpati.com filter

### DIFF
--- a/swaccha-static-adblock-filters.txt
+++ b/swaccha-static-adblock-filters.txt
@@ -115,7 +115,6 @@ www.khelpati.com##.bigyapan-box
 ! ----- END https://www.khelpati.com -----
 
 ! ----- START https://www.nepalpress.com -----
-www.khelpati.com##.bigyapan-box
 www.nepalpress.com##.gam-each-ad
 ! ----- END https://www.nepalpress.com -----
 


### PR DESCRIPTION
A copy of the filter of khelpati was mistakenly added in nepalpress section.